### PR TITLE
Move sealer nodes into private subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ module "sealer1" {
 
   bootnode_enode = "${var.bootnode_enode}"
   bootnode_port = "${module.bootnode.port}"
-  bootnode_ip   = "${aws_eip.bootnode.public_ip}"
+  bootnode_ip   = "${module.bootnode.public_ip}"
 }
 
 module "sealer2" {
@@ -61,7 +61,7 @@ module "sealer2" {
 
   bootnode_enode = "${var.bootnode_enode}"
   bootnode_port = "${module.bootnode.port}"
-  bootnode_ip   = "${aws_eip.bootnode.public_ip}"
+  bootnode_ip   = "${module.bootnode.public_ip}"
 }
 
 module "rpc" {
@@ -76,7 +76,7 @@ module "rpc" {
 
   bootnode_enode = "${var.bootnode_enode}"
   bootnode_port = "${module.bootnode.port}"
-  bootnode_ip   = "${aws_eip.bootnode.public_ip}"
+  bootnode_ip   = "${module.bootnode.public_ip}"
 }
 
 // -----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ module "sealer1" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${aws_eip.ethstats.public_ip}"
+  ethstats_ip = "${module.ethstats.public_ip}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -56,7 +56,7 @@ module "sealer2" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${aws_eip.ethstats.public_ip}"
+  ethstats_ip = "${module.ethstats.public_ip}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -71,7 +71,7 @@ module "rpc" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${aws_eip.ethstats.public_ip}"
+  ethstats_ip = "${module.ethstats.public_ip}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -84,7 +84,7 @@ module "rpc" {
 // -----------------------------------------------------------------------------
 
 output "ethstats" {
-  value = "http://${aws_eip.ethstats.public_ip}:${module.ethstats.port}"
+  value = "http://${module.ethstats.public_ip}:${module.ethstats.port}"
 }
 
 output "rpc" {

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ module "sealer1" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${module.ethstats.public_ip}"
+  ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -56,7 +56,7 @@ module "sealer2" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${module.ethstats.public_ip}"
+  ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -71,7 +71,7 @@ module "rpc" {
   vpc_id                = "${aws_vpc.circles.id}"
   subnet_id             = "${aws_subnet.circles.id}"
 
-  ethstats_ip = "${module.ethstats.public_ip}"
+  ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
 
   bootnode_enode = "${var.bootnode_enode}"
@@ -84,7 +84,7 @@ module "rpc" {
 // -----------------------------------------------------------------------------
 
 output "ethstats" {
-  value = "http://${module.ethstats.public_ip}:${module.ethstats.port}"
+  value = "http://${aws_route53_record.ethstats.fqdn}:${module.ethstats.port}"
 }
 
 output "rpc" {

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ module "sealer1" {
   secrets_key = "circles-sealer-1"
   instance_profile_name = "${aws_iam_instance_profile.sealer1.name}"
   vpc_id                = "${module.vpc.vpc_id}"
-  subnet_id             = "${local.public_subnet_id}"
+  subnet_id             = "${local.private_subnet_id}"
 
   ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
@@ -54,7 +54,7 @@ module "sealer2" {
   secrets_key = "circles-sealer-2"
   instance_profile_name = "${aws_iam_instance_profile.sealer2.name}"
   vpc_id                = "${module.vpc.vpc_id}"
-  subnet_id             = "${local.public_subnet_id}"
+  subnet_id             = "${local.private_subnet_id}"
 
   ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"

--- a/main.tf
+++ b/main.tf
@@ -18,16 +18,16 @@ module "ethstats" {
   source = "services/ethstats"
 
   instance_profile_name = "${aws_iam_instance_profile.ethstats.name}"
-  vpc_id                = "${aws_vpc.circles.id}"
-  subnet_id             = "${aws_subnet.circles.id}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  subnet_id             = "${local.public_subnet_id}"
 }
 
 module "bootnode" {
   source = "services/bootnode"
 
   instance_profile_name = "${aws_iam_instance_profile.bootnode.name}"
-  vpc_id                = "${aws_vpc.circles.id}"
-  subnet_id             = "${aws_subnet.circles.id}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  subnet_id             = "${local.public_subnet_id}"
 }
 
 module "sealer1" {
@@ -36,8 +36,8 @@ module "sealer1" {
 
   secrets_key = "circles-sealer-1"
   instance_profile_name = "${aws_iam_instance_profile.sealer1.name}"
-  vpc_id                = "${aws_vpc.circles.id}"
-  subnet_id             = "${aws_subnet.circles.id}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  subnet_id             = "${local.public_subnet_id}"
 
   ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
@@ -53,8 +53,8 @@ module "sealer2" {
 
   secrets_key = "circles-sealer-2"
   instance_profile_name = "${aws_iam_instance_profile.sealer2.name}"
-  vpc_id                = "${aws_vpc.circles.id}"
-  subnet_id             = "${aws_subnet.circles.id}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  subnet_id             = "${local.public_subnet_id}"
 
   ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"
@@ -68,8 +68,8 @@ module "rpc" {
   source = "services/rpc"
 
   instance_profile_name = "${aws_iam_instance_profile.rpc.name}"
-  vpc_id                = "${aws_vpc.circles.id}"
-  subnet_id             = "${aws_subnet.circles.id}"
+  vpc_id                = "${module.vpc.vpc_id}"
+  subnet_id             = "${local.public_subnet_id}"
 
   ethstats = "${module.ethstats.public_ip}:${module.ethstats.port}"
   efs_id       = "${aws_efs_file_system.circles.id}"

--- a/network.tf
+++ b/network.tf
@@ -7,6 +7,7 @@
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "1.32.0"
 
   name = "circles-vpc"
   cidr = "10.0.0.0/16"

--- a/network.tf
+++ b/network.tf
@@ -1,8 +1,5 @@
 // -----------------------------------------------------------------------------
-// NETWORK
-//
-// Defines a VPC with a single publicly visible subnet
-// see: https://ops.tips/blog/a-pratical-look-at-basic-aws-networking/
+// VPC
 // -----------------------------------------------------------------------------
 
 module "vpc" {

--- a/network.tf
+++ b/network.tf
@@ -48,7 +48,7 @@ resource "aws_route53_zone" "circles" {
   name = "${var.domain}"
 }
 
-resource "aws_route53_record" "stats" {
+resource "aws_route53_record" "ethstats" {
   zone_id = "${aws_route53_zone.circles.zone_id}"
   name    = "stats.${var.domain}"
   type    = "A"

--- a/network.tf
+++ b/network.tf
@@ -41,17 +41,24 @@ resource "aws_route" "internet_access" {
 }
 
 // -----------------------------------------------------------------------------
-// Static IP
+// DNS
 // -----------------------------------------------------------------------------
 
-resource "aws_eip" "ethstats" {
-  instance = "${module.ethstats.instance_id}"
-  vpc      = true
-
-  tags {
-    Name = "circles-ethstats"
-  }
+resource "aws_route53_zone" "circles" {
+  name = "${var.domain}"
 }
+
+resource "aws_route53_record" "stats" {
+  zone_id = "${aws_route53_zone.circles.zone_id}"
+  name    = "stats.${var.domain}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${module.ethstats.public_ip}"]
+}
+
+// -----------------------------------------------------------------------------
+// Static IP
+// -----------------------------------------------------------------------------
 
 resource "aws_eip" "rpc" {
   instance = "${module.rpc.instance_id}"

--- a/network.tf
+++ b/network.tf
@@ -56,21 +56,20 @@ resource "aws_route53_record" "ethstats" {
   records = ["${module.ethstats.public_ip}"]
 }
 
+resource "aws_route53_record" "bootnode" {
+  zone_id = "${aws_route53_zone.circles.zone_id}"
+  name    = "boot.${var.domain}"
+  type    = "A"
+  ttl     = "300"
+  records = ["${module.bootnode.public_ip}"]
+}
+
 // -----------------------------------------------------------------------------
 // Static IP
 // -----------------------------------------------------------------------------
 
 resource "aws_eip" "rpc" {
   instance = "${module.rpc.instance_id}"
-  vpc      = true
-
-  tags {
-    Name = "circles-rpc"
-  }
-}
-
-resource "aws_eip" "bootnode" {
-  instance = "${module.bootnode.instance_id}"
   vpc      = true
 
   tags {

--- a/network.tf
+++ b/network.tf
@@ -5,39 +5,23 @@
 // see: https://ops.tips/blog/a-pratical-look-at-basic-aws-networking/
 // -----------------------------------------------------------------------------
 
-resource "aws_vpc" "circles" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
 
-  tags {
-    Name = "circles-vpc"
-  }
+  name = "circles-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["${var.availability_zone}"]
+  private_subnets = ["10.0.1.0/24"]
+  public_subnets  = ["10.0.101.0/24"]
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = false
 }
 
-resource "aws_subnet" "circles" {
-  vpc_id                  = "${aws_vpc.circles.id}"
-  cidr_block              = "10.0.0.0/24"
-  availability_zone       = "${var.availability_zone}"
-  map_public_ip_on_launch = true
-
-  tags {
-    Name = "circles-subnet"
-  }
-}
-
-resource "aws_internet_gateway" "circles" {
-  vpc_id = "${aws_vpc.circles.id}"
-
-  tags {
-    Name = "circles-internet-gateway"
-  }
-}
-
-resource "aws_route" "internet_access" {
-  route_table_id         = "${aws_vpc.circles.main_route_table_id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.circles.id}"
+locals {
+  public_subnet_id = "${module.vpc.public_subnets[0]}"
+  private_subnet_id = "${module.vpc.private_subnets[0]}"
 }
 
 // -----------------------------------------------------------------------------

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Running, but under heavy development. Not production ready. See [todo](#todo)
 
 - Monitor the current status of the cluster with our ethstats instance at: [stats.circles.com](http://stats.circles-chain.com)
 - Connect metamask to the RPC node at: http://18.184.227.148:8545
-- Connect your own node to the cluster using the [`gensis.json`](resources/genesis.json) and the bootnode at [35.157.62.211](35.157.62.211)
+- Connect your own node to the cluster using the [`gensis.json`](resources/genesis.json) and the bootnode at [boot.circles-chain.com](http://boot.circles-chain.com)
 
 ## Bringing Up the AWS environment
 
@@ -108,6 +108,7 @@ Each service runs on a single burstable t2.micro instance (defined in [services/
 
 ### Small
 
+- [ ] metamask cannot connect to rpc w./ DNS, only w./ IP
 - [ ] Cap size of log file on disk
 - [ ] Unify geth version parameters
 - [ ] Services should not be run as root

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Running, but under heavy development. Not production ready. See [todo](#todo)
 
 ## Using the Cluster
 
-- Monitor the current status of the cluster with our ethstats instance at: http://18.184.187.168:3000
+- Monitor the current status of the cluster with our ethstats instance at: [stats.circles.com](http://stats.circles-chain.com)
 - Connect metamask to the RPC node at: http://18.184.227.148:8545
 - Connect your own node to the cluster using the [`gensis.json`](resources/genesis.json) and the bootnode at [35.157.62.211](35.157.62.211)
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Running, but under heavy development. Not production ready. See [todo](#todo)
 ### Network
 
 - defined in [network.tf](network.tf)
-- 1 internet visible subnet inside 1 vpc. (eu-central-1a)
+- 1 private & 1 public subnet in eu-central-1
 
 ### Logging
 
@@ -78,6 +78,7 @@ Each service runs on a single burstable t2.micro instance (defined in [services/
 - produces blocks
 - holds private keys
 - running geth
+- private subnet
 
 ### [rpc](services/rpc/main.tf)
 
@@ -85,17 +86,20 @@ Each service runs on a single burstable t2.micro instance (defined in [services/
 - relays blocks to sealer
 - allows interaction with metamask
 - running geth
+- public subnet
 
 ### [bootnode](services/bootnode/main.tf)
 
 - service discovery
 - requires open udp ports to the network
 - running geth
+- public subnet
 
 ### [ethstats](services/ethstats.tf)
 
 - monitoring dashboard for the cluster
 - running [eth-netstats](https://github.com/cubedro/eth-netstats)
+- public subnet
 
 ## TODO
 

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,6 @@ Each service runs on a single burstable t2.micro instance (defined in [services/
 
 ### Big
 
-- [ ] Segregate sealer nodes into a private subnet
 - [ ] Define staging environment & deployment pipeline
 - [ ] Define (and ideally automate) secret rotation procedures
 - [ ] Backup chain state (ideally some versioned / snapshotting system). Test restoration from these backups.

--- a/services/base/outputs.tf
+++ b/services/base/outputs.tf
@@ -1,3 +1,7 @@
 output "instance_id" {
   value = "${aws_instance.this.id}"
 }
+
+output "public_ip" {
+  value = "${aws_instance.this.public_ip}"
+}

--- a/services/bootnode/outputs.tf
+++ b/services/bootnode/outputs.tf
@@ -5,3 +5,7 @@ output "port" {
 output "instance_id" {
   value = "${module.bootnode.instance_id}"
 }
+
+output "public_ip" {
+  value = "${module.bootnode.public_ip}"
+}

--- a/services/ethstats/cloud-config.yaml
+++ b/services/ethstats/cloud-config.yaml
@@ -8,4 +8,4 @@ runcmd:
   - python3 /get_secret.py --name "circles-ws-secret" --value "ws-secret" --output /secrets/ws-secret
 
   - service docker start
-  - docker run --publish 3000:3000 --env WS_SECRET=$(cat /secrets/ws-secret) puppeth/ethstats
+  - docker run --publish ${ethstats_port}:3000 --env WS_SECRET=$(cat /secrets/ws-secret) puppeth/ethstats

--- a/services/ethstats/inputs.tf
+++ b/services/ethstats/inputs.tf
@@ -16,5 +16,5 @@ variable "subnet_id" {
 
 variable "ethstats_port" {
   description = "Port to expose the ethstats service on"
-  default     = 3000
+  default     = 80
 }

--- a/services/ethstats/main.tf
+++ b/services/ethstats/main.tf
@@ -1,5 +1,9 @@
 data "template_file" "cloud_config" {
   template = "${file("${path.module}/cloud-config.yaml")}"
+
+  vars {
+    ethstats_port = "${var.ethstats_port}"
+  }
 }
 
 module "ethstats" {

--- a/services/ethstats/outputs.tf
+++ b/services/ethstats/outputs.tf
@@ -2,6 +2,10 @@ output "instance_id" {
   value = "${module.ethstats.instance_id}"
 }
 
+output "public_ip" {
+  value = "${module.ethstats.public_ip}"
+}
+
 output "port" {
   value = "${var.ethstats_port}"
 }

--- a/services/rpc/cloud-config.yaml
+++ b/services/rpc/cloud-config.yaml
@@ -27,4 +27,4 @@ runcmd:
   - python3 /get_secret.py --name "circles-ws-secret" --value "ws-secret" --output /secrets/ws-secret
 
   # start rpc node
-  - 'geth --syncmode "full" --networkid "${network_id}" --rpc --rpcapi="eb3,eth,net,debug" --rpcport "${rpc_port}" --rpcaddr "0.0.0.0" --rpccorsdomain "*" --datadir "/chain" --keystore "/keystore" --ethstats "rpc:$(cat /secrets/ws-secret)@${ethstats_ip}:3000" --bootnodes "enode://${bootnode_enode}@${bootnode_ip}:${bootnode_port}"'
+  - 'geth --syncmode "full" --networkid "${network_id}" --rpc --rpcapi="eb3,eth,net,debug" --rpcport "${rpc_port}" --rpcaddr "0.0.0.0" --rpccorsdomain "*" --datadir "/chain" --keystore "/keystore" --ethstats "rpc:$(cat /secrets/ws-secret)@${ethstats}" --bootnodes "enode://${bootnode_enode}@${bootnode_ip}:${bootnode_port}"'

--- a/services/rpc/inputs.tf
+++ b/services/rpc/inputs.tf
@@ -26,8 +26,8 @@ variable "rpc_port" {
   default     = 8545
 }
 
-variable "ethstats_ip" {
-  description = "dns name of ethstats instance"
+variable "ethstats" {
+  description = "hostname:port for ethstats"
 }
 
 variable "bootnode_ip" {

--- a/services/rpc/main.tf
+++ b/services/rpc/main.tf
@@ -15,7 +15,7 @@ data "template_file" "cloud_config" {
     network_id     = "46781"
     sealer_account = "e477eaddcb3d365061083f60f14a4cf4d2782f96"
     efs_id         = "${var.efs_id}"
-    ethstats_ip   = "${var.ethstats_ip}"
+    ethstats   = "${var.ethstats}"
     bootnode_enode = "${var.bootnode_enode}"
     bootnode_ip    = "${var.bootnode_ip}"
     bootnode_port  = "${var.bootnode_port}"

--- a/services/sealer/cloud-config.yaml
+++ b/services/sealer/cloud-config.yaml
@@ -30,4 +30,4 @@ runcmd:
   - python3 /get_secret.py --name "circles-ws-secret" --value "ws-secret" --output /secrets/ws-secret
 
   # start sealer
-  - 'geth --gasprice "0" --syncmode "full" --networkid ${network_id} --mine --datadir /chain --keystore /keystore --unlock `cat /secrets/sealer-address` --password /secrets/sealer-password --ethstats "${name}:$(cat /secrets/ws-secret)@${ethstats_ip}:3000" --bootnodes enode://${bootnode_enode}@${bootnode_ip}:${bootnode_port}'
+  - 'geth --gasprice "0" --syncmode "full" --networkid ${network_id} --mine --datadir /chain --keystore /keystore --unlock `cat /secrets/sealer-address` --password /secrets/sealer-password --ethstats "${name}:$(cat /secrets/ws-secret)@${ethstats}" --bootnodes enode://${bootnode_enode}@${bootnode_ip}:${bootnode_port}'

--- a/services/sealer/inputs.tf
+++ b/services/sealer/inputs.tf
@@ -27,8 +27,8 @@ variable "geth_port" {
   default     = 30303
 }
 
-variable "ethstats_ip" {
-  description = "dns name of ethstats instance"
+variable "ethstats" {
+  description = "hostname:port for ethstats"
 }
 
 variable "bootnode_ip" {

--- a/services/sealer/main.tf
+++ b/services/sealer/main.tf
@@ -14,7 +14,7 @@ data "template_file" "cloud_config" {
     geth_commit    = "66432f38"
     network_id     = "46781"
     efs_id         = "${var.efs_id}"
-    ethstats_ip   = "${var.ethstats_ip}"
+    ethstats   = "${var.ethstats}"
     bootnode_enode = "${var.bootnode_enode}"
     bootnode_ip    = "${var.bootnode_ip}"
     bootnode_port  = "${var.bootnode_port}"

--- a/storage.tf
+++ b/storage.tf
@@ -16,13 +16,13 @@ resource "aws_efs_file_system" "circles" {
 
 resource "aws_efs_mount_target" "circles" {
   file_system_id  = "${aws_efs_file_system.circles.id}"
-  subnet_id       = "${aws_subnet.circles.id}"
+  subnet_id       = "${local.public_subnet_id}"
   security_groups = ["${aws_security_group.circles_efs_mount_target.id}"]
 }
 
 resource "aws_security_group" "circles_efs_mount_target" {
   name   = "circles_efs_mount_target"
-  vpc_id = "${aws_vpc.circles.id}"
+  vpc_id = "${module.vpc.vpc_id}"
 
   ingress {
     from_port   = 2049

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,8 @@ variable "bootnode_enode" {
     description = "Which enode should the sealer and rpc nodes connect to"
     default = "07d24a7a560c4b4011b71c94db03f48afba2bbb0d37b7a403d25bd86bb4d55e521b9f646371b99fdca194423a412d526613c991c493ca84af93e9c01e184f56a"
 }
+
+variable "domain" {
+    description = "Which domain should the route53 records be created for"
+    default = "circles-chain.com"
+}


### PR DESCRIPTION
Moves block producers (a.k.a sealers) into a private subnet.

- register circles-chain.com domain name
- Remove elastic IP's and assign DNS entries for stats & boot nodes (only have 5 EIP's per region and needed them for NAT gateways)
- replace custom network code with official terraform aws vpc module (https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/1.31.0)
- Move sealer nodes into private subnet