### PR TITLE
Docker-compose file for bringing up a full node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,15 +9,19 @@ Running, but under heavy development. Not production ready. See [todo](#todo)
 ## Using the Cluster
 
 - Monitor the current status of the cluster with our ethstats instance at: [stats.circles.com](http://stats.circles-chain.com)
-- Connect metamask to the RPC node at: http://18.184.227.148:8545
-- Connect your own node to the cluster using the [`gensis.json`](resources/genesis.json) and the bootnode at [boot.circles-chain.com](http://boot.circles-chain.com)
+- Connect metamask to the RPC node at: http://35.158.153.37:8545
+
+## Connecting a node
+
+1.  Clone this repo
+1.  From the project root run: `NAME=<YOUR_NAME> docker-compose -f resources/fullnode.docker-compose.yaml up`
 
 ## Bringing Up the AWS environment
 
-1. Install [terraform](https://www.terraform.io/)
-1. Create an [aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
-1. `terraform init`
-1. `terraform apply`
+1.  Install [terraform](https://www.terraform.io/)
+1.  Create an [aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
+1.  `terraform init`
+1.  `terraform apply`
 
 ## Operating the Cluster
 

--- a/resources/fullnode.docker-compose.yaml
+++ b/resources/fullnode.docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  geth:
+    build:
+      context: .
+      dockerfile: fullnode.dockerfile
+    environment:
+        NODE_NAME: "${NAME}-fullnode"
+    ports:
+     - "8545:8545"
+     - "30303:30303"
+     - "30303:30303/udp"

--- a/resources/fullnode.dockerfile
+++ b/resources/fullnode.dockerfile
@@ -1,0 +1,17 @@
+FROM ethereum/client-go:v1.8.12
+
+RUN apk update && apk add bind-tools curl
+
+RUN curl -O https://raw.githubusercontent.com/CirclesUBI/blockchain-provisioning/master/resources/genesis.json
+RUN geth init --datadir /data /genesis.json
+RUN echo '["enode://2911761ebcfd615fff958ae989532e2b0aad29d0f2c6150a4b06d4a2e9830e3f67e346b59dea401f99ecc91332cf3dc0f3330657dad2ae3d43ad0c70bfa72c52@35.158.153.37:30303"]' > /data/geth/static-nodes.json
+
+ENTRYPOINT ntpd /etc/ntpd.conf && /usr/local/bin/geth \
+    --datadir /data \
+    --syncmode "full" \
+    --ethstats "${NODE_NAME}:76bGpbD3HxxE3vxz@$(dig +short stats.circles-chain.com | tr -d '[:space:]'):80" \
+    --nodiscover \
+    --rpc \
+    --rpcapi admin,debug,miner,personal,txpool,eth,shh,web3 \
+    --networkid 46781 \
+    --nat extip:35.158.153.37 \


### PR DESCRIPTION
This change adds docker resources and instructions that can be used to spin up a local fullnode connected to the circles chain.

Please try it out and let me know how it goes. The node should show up at stats.circles-chain.com.